### PR TITLE
update to give deploy process write premisions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update to the GitHub Actions workflow by adding write permissions for the `contents` scope. This change allows the workflow to perform actions such as pushing commits or creating releases.